### PR TITLE
Sync fix for SVP DMA issue #13 to upstream

### DIFF
--- a/fc1004.v
+++ b/fc1004.v
@@ -206,7 +206,8 @@ module fc1004
 	output [9:0] tmss_address,
 	output vdp_hsync2,
 	input ym2612_status_enable,
-	output vdp_dma_oe_early
+	output vdp_dma_oe_early,
+	output vdp_dma
 	);
 	
 	wire vdp_ys; // w1009
@@ -372,7 +373,8 @@ module fc1004
 		.vdp_psg_clk1(vdp_psg_clk1),
 		.vdp_hsync2(vdp_hsync2),
 		.vdp_cramdot_dis(vdp_cramdot_dis),
-		.vdp_dma_oe_early(vdp_dma_oe_early)
+		.vdp_dma_oe_early(vdp_dma_oe_early),
+		.vdp_dma(vdp_dma)
 		);
 	
 	ym3438 fm

--- a/md_board.v
+++ b/md_board.v
@@ -130,7 +130,8 @@ module md_board
 	input dma_z80_req,
 	output dma_z80_ack,
 	output res_z80,
-	output vdp_dma_oe_early
+	output vdp_dma_oe_early,
+	output vdp_dma
 	
 	);
 	
@@ -485,7 +486,8 @@ module md_board
 		.tmss_address(tmss_address),
 		.vdp_hsync2(vdp_hsync2),
 		.ym2612_status_enable(ym2612_status_enable),
-		.vdp_dma_oe_early(vdp_dma_oe_early)
+		.vdp_dma_oe_early(vdp_dma_oe_early),
+		.vdp_dma(vdp_dma)
 		);
 	
 	assign fm_sel23 = TEST0_o;

--- a/ym7101.v
+++ b/ym7101.v
@@ -113,7 +113,8 @@ module ym7101
 	output vdp_psg_clk1,
 	output vdp_hsync2,
 	input  vdp_cramdot_dis,
-	output vdp_dma_oe_early
+	output vdp_dma_oe_early,
+	output vdp_dma
 	);
 
 	wire cpu_sel;
@@ -7274,6 +7275,8 @@ module ym7101
 		(io_m1_dff2_l2 | w15 | w28 | w30 | w102) :
 		(l6 | l8 | w25 | w1153);
 	
+	assign vdp_dma = l6 | l8;
+
 endmodule
 
 module ym7101_rs_trig


### PR DESCRIPTION
Sorgelig made this change to solve an issue with the SVP chip, figured it should probably be merged back into the upstream to keep the cores in sync.

https://github.com/MiSTer-devel/MegaDrive_MiSTer/commit/bb904945f6b9c4788d1fb76ea40866c72bd22e85